### PR TITLE
Update ruby_version requirement to allow ruby 3.0

### DIFF
--- a/simplecov-html.gemspec
+++ b/simplecov-html.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.summary     = gem.description
   gem.license     = "MIT"
 
-  gem.required_ruby_version = "~> 2.4"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Ruby master branch recently bumped the version number to 3.0: https://github.com/ruby/ruby/commit/21c62fb670b1646c5051a46d29081523cd782f11

This is breaking our ruby-head CI.