### PR TITLE
[feature] Add inline assets option

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -20,7 +20,7 @@ module SimpleCov
       def initialize
         @branchable_result = SimpleCov.branch_coverage?
         @templates = {}
-        @inline_assets = !ENV['SIMPLECOV_INLINE_ASSETS'].nil?
+        @inline_assets = !ENV["SIMPLECOV_INLINE_ASSETS"].nil?
         @public_assets_dir = File.join(File.dirname(__FILE__), "../public/")
       end
 

--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -20,11 +20,12 @@ module SimpleCov
         @branchable_result = SimpleCov.branch_coverage?
         @templates = {}
         @inline_assets = !ENV['SIMPLECOV_INLINE_ASSETS'].nil?
+        @public_assets_dir = File.join(File.dirname(__FILE__), "../public/")
       end
 
       def format(result)
         unless @inline_assets
-          Dir[File.join(File.dirname(__FILE__), "../public/*")].each do |path|
+          Dir[File.join(@public_assets_dir, "*")].each do |path|
             FileUtils.cp_r(path, asset_output_path)
           end
         end
@@ -80,7 +81,7 @@ module SimpleCov
       end
 
       def asset_inline(name)
-        path = File.join(File.dirname(__FILE__), "../public/", name)
+        path = File.join(@public_assets_dir, name)
 
         # Only have a few content types, just hardcode them
         content_type = {
@@ -90,7 +91,7 @@ module SimpleCov
           ".css" => "text/css",
         }[File.extname(name)]
 
-        base64_content = Base64.strict_encode64 open(path).read
+        base64_content = Base64.strict_encode64 File.open(path).read
         "data:#{content_type};base64,#{base64_content}"
       end
 

--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -5,6 +5,7 @@ require "cgi"
 require "fileutils"
 require "digest/sha1"
 require "time"
+require "base64"
 
 # Ensure we are using a compatible version of SimpleCov
 major, minor, patch = SimpleCov::VERSION.scan(/\d+/).first(3).map(&:to_i)


### PR DESCRIPTION
This allows simplecov to generate a single `index.html` file and not have to generate an assets folder if the env var `SIMPLECOV_INLINE_ASSETS` is defined

Resolves https://github.com/simplecov-ruby/simplecov-html/issues/33

Based on the implementation by @eins78 https://github.com/eins78/simplecov-html/commit/939548dabd76d626565ff25f53eda21dd0f8417a