### PR TITLE
Show Branch Coverage in stdout if enabled.

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -32,7 +32,9 @@ module SimpleCov
       end
 
       def output_message(result)
-        "Coverage report generated for #{result.command_name} to #{output_path}. #{result.covered_lines} / #{result.total_lines} LOC (#{result.covered_percent.round(2)}%) covered."
+        output = "Coverage report generated for #{result.command_name} to #{output_path}."
+        output += "\nLine Coverage: #{result.covered_lines} / #{result.total_lines} (#{result.covered_percent.round(2)}%)"
+        output += "\nBranch Coverage: #{result.covered_branches} / #{result.total_branches} (#{result.coverage_statistics[:branch].percent.round(2)}%)" if branchable_result?
       end
 
       def branchable_result?

--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -33,8 +33,8 @@ module SimpleCov
 
       def output_message(result)
         output = "Coverage report generated for #{result.command_name} to #{output_path}."
-        output += "\nLine Coverage: #{result.covered_lines} / #{result.total_lines} (#{result.covered_percent.round(2)}%)"
-        output += "\nBranch Coverage: #{result.covered_branches} / #{result.total_branches} (#{result.coverage_statistics[:branch].percent.round(2)}%)" if branchable_result?
+        output += "\nLine Coverage: #{result.covered_percent.round(2)}% (#{result.covered_lines} / #{result.total_lines})"
+        output += "\nBranch Coverage: #{result.coverage_statistics[:branch].percent.round(2)}% (#{result.covered_branches} / #{result.total_branches})" if branchable_result?
       end
 
       def branchable_result?


### PR DESCRIPTION
Prior to this only Line Coverage is shown in the stdout. 

Branch coverage is equally important, when it is enabled, so it should be shown alongside it to ensure adequate coverage of the code base.

Now it shows in a clean format, including covered branches, total branches and percent of covered branches. I also moved the percentages first and the coverage and total lines/branches afterwards in brackets. So it looks something like this: 

```
Coverage report generated for (1/10), (10/10), (2/10), (3/10), (4/10), (5/10), (6/10), (7/10), (8/10), (9/10) to /Users/me/Development/cntral/coverage.
Line Coverage: 58.44% (7554 / 12927)
Branch Coverage: 50.43% (1868 / 3704)
```

When branch coverage is not enabled it simply omits that line, so it appears like this: 

```
Coverage report generated for (1/10), (10/10), (2/10), (3/10), (4/10), (5/10), (6/10), (7/10), (8/10), (9/10) to /Users/me/Development/cntral/coverage.
Line Coverage: 58.44% (7554 / 12927)
```