### PR TITLE
Improve clarity of line and branch coverage format.

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -38,9 +38,10 @@ module SimpleCov
       end
 
       def output_message(result)
-        str = "Coverage report generated for #{result.command_name} to #{output_path}. #{result.covered_lines} / #{result.total_lines} LOC (#{result.covered_percent.round(2)}%) covered."
-        str += " #{result.covered_branches} / #{result.total_branches} branches (#{result.coverage_statistics[:branch].percent.round(2)}%) covered." if branchable_result?
-        str
+        output = "Coverage report generated for #{result.command_name} to #{output_path}."
+        output += "\nLine Coverage: #{result.covered_percent.round(2)}% (#{result.covered_lines} / #{result.total_lines})"
+        output += "\nBranch Coverage: #{result.coverage_statistics[:branch].percent.round(2)}% (#{result.covered_branches} / #{result.total_branches})" if branchable_result?
+        output
       end
 
       def branchable_result?


### PR DESCRIPTION
- Put percentage first and then covered and total counts in brackets afterwards. Percentage is most critical at a quick glance.

- Put line and brnach coverage on separate lines.


### Before

```bash
Coverage report generated for (1/10), (10/10), (2/10), (3/10), (4/10), (5/10), (6/10), (7/10), (8/10), (9/10) to /Users/me/Development/cntral/coverage. 8534 / 16083 LOC (53.06%) covered. 2225 / 4749 branches (46.85%) covered.
```


### After

Now it shows in a clean format, including covered branches, total branches and percent of covered branches. Something like this:

```
Coverage report generated for (1/10), (10/10), (2/10), (3/10), (4/10), (5/10), (6/10), (7/10), (8/10), (9/10) to /Users/me/Development/cntral/coverage.
Line Coverage: 53.06% (8534 / 16083)
Branch Coverage: 46.85% (2225 / 4749)
```

When branch coverage is not enabled it simply omits that line, so it appears like this:

```
Coverage report generated for (1/10), (10/10), (2/10), (3/10), (4/10), (5/10), (6/10), (7/10), (8/10), (9/10) to /Users/me/Development/cntral/coverage.
Line Coverage: 53.06% (8534 / 16083)
```