### PR TITLE
Bring back self-assignment to suppress Ruby warning

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -111,7 +111,7 @@ module SimpleCov
         # Silence a warning by using the following variable to assign to itself:
         # "warning: possibly useless use of a variable in void context"
         # The variable is used by ERB via binding.
-        title_id = title_id
+        title_id = title_id # rubocop:disable Lint/SelfAssignment
         template("file_list").result(binding)
       end
 

--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -108,6 +108,10 @@ module SimpleCov
       # Returns a table containing the given source files
       def formatted_file_list(title, source_files)
         title_id = title.gsub(/^[^a-zA-Z]+/, "").gsub(/[^a-zA-Z0-9\-_]/, "")
+        # Silence a warning by using the following variable to assign to itself:
+        # "warning: possibly useless use of a variable in void context"
+        # The variable is used by ERB via binding.
+        title_id = title_id
         template("file_list").result(binding)
       end
 


### PR DESCRIPTION
This reverts commit 1ec2e3ba72046f7d1fa5288f726aba75535cb826.

I don't remember why I thought this self-assignment is omittable, but the fact is that Ruby actually warns without this...