### PR TITLE
Reduce gem package size by excluding assets directory

### DIFF
--- a/simplecov-html.gemspec
+++ b/simplecov-html.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
       (File.expand_path(f) == __FILE__) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile assets .rubocop.yml Guardfile])
     end
   end
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/simplecov-html.gemspec
+++ b/simplecov-html.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.files         = `git ls-files`.split("\n")
+  gem.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+    end
+  end
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.require_paths = ["lib"]


### PR DESCRIPTION
Gem package size of this gem is significantly becoming larger in recent versions.
```
simplecov-html-0.11.0: 744K
simplecov-html-0.12.0: 1.3M
simplecov-html-0.12.3: 1.3M
```

This seems to be caused via 0eccc9ceacc1d97989c62bcf5fda5836e8315e14 which adds a new js library and starts bundling non-minified version of jQuery. That commit at the same time introduces assets compression, and hence that change didn't really impact the actual runtime performance, but resulted in gem package size growth.

However, since asset files under `assets` directory are used only during precompilation phase and not referenced in users' side, the whole directory can be safely omitted from the gem package.

This patch removes some "development only" files including the `assets` directory. Result of the installed gem size is as follows:
```
simplecov-html-0.11.0: 744K
simplecov-html-0.12.0: 1.3M
simplecov-html-0.12.3: 1.3M
simplecov-html-next: 444K
```