### PR TITLE
Avoid "permission denied" errors copying assets

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -27,7 +27,7 @@ module SimpleCov
       def format(result)
         unless @inline_assets
           Dir[File.join(@public_assets_dir, "*")].each do |path|
-            FileUtils.cp_r(path, asset_output_path)
+            FileUtils.cp_r(path, asset_output_path, remove_destination: true)
           end
         end
 


### PR DESCRIPTION
by running `FileUtils#cp_r` with the `:remove_destination` option enabled.  This makes asset copying more robust in the face of restrictive permissions on asset file destination paths.  This should be safe and backward-compatible given that the destination files (or their contents) will be fully replaced anyway.

Example case:

```
irb(main):001:0> FileUtils.touch('foo')
=> ["foo"]
irb(main):002:0> FileUtils.touch('bar')
=> ["bar"]
irb(main):003:0> FileUtils.chmod(0o444, 'bar')
=> ["bar"]
irb(main):004:0> FileUtils.cp_r('foo', 'bar')
Errno::EACCES: Permission denied @ rb_sysopen - bar from /nix/store/2kw126cy93rix4pmh9lcl120njnb6r7r-ruby-3.1.4/lib/ruby/3.1.0/fileutils.rb:1395:in `initialize' 
irb(main):005:0> FileUtils.cp_r('foo', 'bar', remove_destination: true) 
=> nil
```

Addresses https://github.com/simplecov-ruby/simplecov/issues/741.

Thanks!