### PR TITLE
Bring Ruby 2.4+ support back

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
 
       matrix:
         ruby-version:
+          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
 
       matrix:
         ruby-version:
+          - '2.5'
           - '2.6'
           - '2.7'
           - '3.0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - run: rm Gemfile.lock
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
 
       matrix:
         ruby-version:
+          - '2.4'
           - '2.5'
           - '2.6'
           - '2.7'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 AllCops:
   DisplayCopNames: true
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.5
 
 Bundler/DuplicatedGem:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 AllCops:
   DisplayCopNames: true
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.6
 
 Bundler/DuplicatedGem:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "bundler", "~> 2.4.0"
 gem "rake", ">= 11"
 
 # Use local copy of simplecov in development if you want to

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :test do
 end
 
 group :development do
-  gem "rubocop"
+  gem "rubocop", "~> 1.50.2"
   gem "rubocop-minitest"
   gem "rubocop-performance"
   gem "rubocop-rake"

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :test do
 end
 
 group :development do
-  gem "rubocop", "~> 1.50.2"
+  gem "rubocop"
   gem "rubocop-minitest"
   gem "rubocop-performance"
   gem "rubocop-rake"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,11 @@ gem "rake", ">= 11"
 
 # Use local copy of simplecov in development if you want to
 # gem "simplecov", :path => File.dirname(__FILE__) + "/../simplecov"
-gem "simplecov", git: "https://github.com/simplecov-ruby/simplecov"
+if RUBY_VERSION < "2.5"
+  gem "simplecov", "< 0.19"
+else
+  gem "simplecov", git: "https://github.com/simplecov-ruby/simplecov"
+end
 
 group :test do
   gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,6 @@ GEM
     execjs (2.9.1)
     json (2.7.1)
     json (2.7.1-java)
-    language_server-protocol (3.17.0.3)
     minitest (5.20.0)
     parallel (1.24.0)
     parser (3.2.2.4)
@@ -35,15 +34,14 @@ GEM
     regexp_parser (2.8.3)
     rexml (3.3.6)
       strscan
-    rubocop (1.59.0)
+    rubocop (1.50.2)
       json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.4)
+      parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
@@ -77,7 +75,7 @@ DEPENDENCIES
   bundler (~> 2.4.0)
   minitest
   rake (>= 11)
-  rubocop
+  rubocop (~> 1.50.2)
   rubocop-minitest
   rubocop-performance
   rubocop-rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/simplecov-ruby/simplecov
-  revision: 1d8f692d772c101c56f3f4e94945e898ad7b3769
+  revision: 0260b1f309e76c8ed87731ebbc348b05d753b8a2
   specs:
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -16,42 +16,38 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    concurrent-ruby (1.2.2)
-    docile (1.4.0)
+    concurrent-ruby (1.3.4)
+    docile (1.4.1)
     execjs (2.9.1)
-    json (2.7.1)
-    json (2.7.1-java)
-    minitest (5.20.0)
+    minitest (5.15.0)
     parallel (1.24.0)
-    parser (3.2.2.4)
+    parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
-    racc (1.7.3)
-    racc (1.7.3-java)
-    rack (3.0.9.1)
+    racc (1.8.1)
+    racc (1.8.1-java)
+    rack (3.1.7)
     rainbow (3.1.1)
-    rake (13.1.0)
-    regexp_parser (2.8.3)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
     rexml (3.3.6)
       strscan
-    rubocop (1.50.2)
-      json (~> 2.3)
+    rubocop (1.28.2)
       parallel (~> 1.10)
-      parser (>= 3.2.0.0)
+      parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.30.0)
-      parser (>= 3.2.1.0)
-    rubocop-minitest (0.34.2)
-      rubocop (>= 1.39, < 2.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
-    rubocop-performance (1.20.1)
-      rubocop (>= 1.48.1, < 2.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.17.0)
+      parser (>= 3.1.1.0)
+    rubocop-minitest (0.19.1)
+      rubocop (>= 0.90, < 2.0)
+    rubocop-performance (1.13.3)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
     ruby-progressbar (1.13.0)
@@ -74,7 +70,7 @@ PLATFORMS
 DEPENDENCIES
   minitest
   rake (>= 11)
-  rubocop (~> 1.50.2)
+  rubocop
   rubocop-minitest
   rubocop-performance
   rubocop-rake
@@ -85,4 +81,4 @@ DEPENDENCIES
   yui-compressor
 
 BUNDLED WITH
-   2.5.3
+   2.3.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  bundler (~> 2.4.0)
   minitest
   rake (>= 11)
   rubocop (~> 1.50.2)
@@ -86,4 +85,4 @@ DEPENDENCIES
   yui-compressor
 
 BUNDLED WITH
-   2.4.22
+   2.5.3

--- a/simplecov-html.gemspec
+++ b/simplecov-html.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.summary     = gem.description
   gem.license     = "MIT"
 
-  gem.required_ruby_version = ">= 2.7"
+  gem.required_ruby_version = ">= 2.6"
 
   gem.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|

--- a/simplecov-html.gemspec
+++ b/simplecov-html.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.summary     = gem.description
   gem.license     = "MIT"
 
-  gem.required_ruby_version = ">= 2.6"
+  gem.required_ruby_version = ">= 2.5"
 
   gem.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|

--- a/simplecov-html.gemspec
+++ b/simplecov-html.gemspec
@@ -10,11 +10,11 @@ Gem::Specification.new do |gem|
   gem.authors     = ["Christoph Olszowka"]
   gem.email       = ["christoph at olszowka de"]
   gem.homepage    = "https://github.com/simplecov-ruby/simplecov-html"
-  gem.description = %(Default HTML formatter for SimpleCov code coverage tool for ruby 2.5+)
+  gem.description = %(Default HTML formatter for SimpleCov code coverage tool for ruby 2.4+)
   gem.summary     = gem.description
   gem.license     = "MIT"
 
-  gem.required_ruby_version = ">= 2.5"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
Here's a similar kind of maintenance work with https://github.com/simplecov-ruby/simplecov/pull/1108
Now the CI is running healtily again on all supported Ruby versions of the latest gem release (2.4+).