### PR TITLE
Drop `base64` dependency, resolve Ruby warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,5 +28,4 @@ group :development do
   gem "uglifier"
 end
 
-gem "base64" if RUBY_VERSION >= "3.3"
 gem "logger" if RUBY_VERSION >= "3.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    base64 (0.2.0)
     concurrent-ruby (1.3.4)
     docile (1.4.1)
     execjs (2.9.1)
@@ -75,7 +74,6 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  base64
   logger
   minitest
   rake (>= 11)

--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -5,7 +5,6 @@ require "cgi"
 require "fileutils"
 require "digest/sha1"
 require "time"
-require "base64"
 
 # Ensure we are using a compatible version of SimpleCov
 major, minor, patch = SimpleCov::VERSION.scan(/\d+/).first(3).map(&:to_i)
@@ -94,7 +93,7 @@ module SimpleCov
 
       def asset_inline(name)
         path = File.join(@public_assets_dir, name)
-        base64_content = Base64.strict_encode64 File.read(path)
+        base64_content = [File.read(path)].pack("m0")
 
         content_type = CONTENT_TYPES[File.extname(name)]
 


### PR DESCRIPTION
`base64` is being used in the gem and so just adding it to the Gemfile is not sufficient. Instead of moving it to the gemspec, just replace it through the equivalent `pack` method call.