### PR TITLE
Fix version check load order issue

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -7,6 +7,7 @@ require "digest/sha1"
 require "time"
 
 # Ensure we are using a compatible version of SimpleCov
+require "simplecov/version"
 major, minor, patch = SimpleCov::VERSION.scan(/\d+/).first(3).map(&:to_i)
 if major < 0 || minor < 9 || patch < 0
   raise "The version of SimpleCov you are using is too old. " \


### PR DESCRIPTION
Checking the version causes an error when `simplecov-html` is loaded before `simplecov`:

```
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "simplecov-html"
  gem "simplecov"
end
```

```
/home/user/code/simplecov-html/lib/simplecov-html.rb:10:in '<top (required)>': uninitialized constant SimpleCov::VERSION (NameError)

major, minor, patch = SimpleCov::VERSION.scan(/\d+/).first(3).map(&:to_i)
                               ^^^^^^^^^
        from <internal:/home/user/.rbenv/versions/3.4-dev/lib/ruby/3.4.0+0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
```

I don't think this check is even needed anymore but I'd just leave it in