### PR TITLE
Only require what is needed from `cgi` for Ruby 3.5 compatibility

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "erb"
-require "cgi"
 require "fileutils"
 require "digest/sha1"
 require "time"

--- a/views/source_file.erb
+++ b/views/source_file.erb
@@ -48,7 +48,7 @@
               <% end %>
             <% end %>
 
-            <code class="ruby"><%= CGI.escapeHTML(line.src.chomp) %></code>
+            <code class="ruby"><%= ERB::Util.html_escape(line.src.chomp) %></code>
           </li>
         </div>
       <% end %>


### PR DESCRIPTION
In ruby 3.5 most of the functionality will require adding cgi as a dependency.

Only escape/unescape functions will remain, which is all that's needed here. `cgi/escape` is available since Ruby 2.3 with `CGI.escapeHTML`

https://bugs.ruby-lang.org/issues/21258.